### PR TITLE
Add missing step when installing Fortify

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ php artisan vendor:publish --provider="Laravel\\Fortify\\FortifyServiceProvider"
 
 php artisan migrate
 ```
+
+Add in `config/app.php`:
+
+```
+ 'providers' => [
+        // ...
+        App\Providers\FortifyServiceProvider::class,
+    ],
+```
+
 4. Run NPM to build your CSS and JS assets using Laravel Mix:
 ```
 npm install && npm run dev


### PR DESCRIPTION
When installing Fortify is required to add providers in config. This is done in automatic only when installing Jetstream.